### PR TITLE
More granularity for gid; minor typo fix.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ IOC log daemon v2
 
 This daemon is a drop in replacement for iocLogServer
 which ships with EPICS Base.
-It incorperats a number of differences (hopefully improvements).
+It incorporates a number of differences (hopefully improvements).
 
 1. Log file rotation instead of overwriting
 1. Log IPs instead of host name (faster and doesn't truncate)
@@ -19,8 +19,8 @@ Configuration
 -------------
 
 The provided [server.conf](server.conf) should work for most sites.
-It listens on the default port 7004, writes all entries to epics.log
-and re-broadcasts on ort 7014.
+It listens on the default port 7004, writes all entries to epics.log,
+and re-broadcasts on port 7014.
 
 Also provided is [server.conf.bnl](server.conf.bnl) which demonstrates
 filtering caputlog entries by user name.

--- a/ioclogserver.init
+++ b/ioclogserver.init
@@ -19,6 +19,7 @@ DESC="Log recorder daemon for EPICS IOCS"
 # defaults
 RUN=no
 RUN_AS_USER=ioclogserver
+RUN_AS_GROUP=nogroup
 
 CONF_FILE="/etc/ioclogserver.conf"
 PID_FILE="/var/run/$NAME.pid"
@@ -28,7 +29,7 @@ if [ -f /etc/default/ioclogserver2 ] ; then
     . /etc/default/ioclogserver2
 fi
 
-DAEMON_OPTS="--logfile=/var/log/epics/daemon.log --pidfile=$PID_FILE --uid=$RUN_AS_USER --gid=$RUN_AS_USER --umask=0022"
+DAEMON_OPTS="--logfile=/var/log/epics/daemon.log --pidfile=$PID_FILE --uid=$RUN_AS_USER --gid=$RUN_AS_GROUP --umask=0022"
 DAEMON_OPTS="$DAEMON_OPTS ioclogserver -C $CONF_FILE -M 2223"
 
 SSD_OPTS="-q --pidfile $PID_FILE"


### PR DESCRIPTION
Adding RUN_AS_GROUP to the init script will allow a more precise control over gid of the log files created.